### PR TITLE
Fix contact email link

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <div class="text-box sponsors">
           <!-- <div class="border-line" ></div> -->
           <p style="font-size: 20px;">
-            Looking to sponsor the largest group of traveling hackers in the South? <a href="twickes32@gmail.com" target="_blank" style="text-decoration: underline;">Send over an email</a> and let’s chat.
+            Looking to sponsor the largest group of traveling hackers in the South? <a href="mailto:twickes32@gmail.com" target="_blank" style="text-decoration: underline;">Send over an email</a> and let’s chat.
           </p>
         </div>
 


### PR DESCRIPTION
Needed the `mailto:` prefix.
